### PR TITLE
Fix navigation links with Next.js Link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 // src/app/page.tsx
 
 import Image from 'next/image'
+import Link from 'next/link'
 
 export default function HomePage() {
   return (
@@ -15,12 +16,12 @@ export default function HomePage() {
           AWS | Kubernetes | Terraform | Tech Support Lead | Advocate for Dyslexia in Tech
         </p>
         <div className="flex flex-col sm:flex-row gap-4">
-          <a href="/resume" className="bg-teal-600 text-white px-6 py-3 rounded-lg shadow hover:bg-teal-700 transition">
+          <Link href="/resume" className="bg-teal-600 text-white px-6 py-3 rounded-lg shadow hover:bg-teal-700 transition">
             View Resume
-          </a>
-          <a href="/contact" className="border border-teal-600 text-teal-600 px-6 py-3 rounded-lg hover:bg-teal-50 transition">
+          </Link>
+          <Link href="/contact" className="border border-teal-600 text-teal-600 px-6 py-3 rounded-lg hover:bg-teal-50 transition">
             Contact Me
-          </a>
+          </Link>
         </div>
         {/* Optional background shape */}
         <div className="absolute inset-0 -z-10 bg-gradient-to-br from-teal-50 via-white to-white" />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,11 +1,13 @@
+import Link from 'next/link'
+
 export default function Navbar() {
   return (
     <nav className="p-4 border-b flex gap-4">
-      <a href="/">Home</a>
-      <a href="/about">About</a>
-      <a href="/resume">Resume</a>
-      <a href="/projects">Projects</a>
-      <a href="/contact">Contact</a>
+      <Link href="/">Home</Link>
+      <Link href="/about">About</Link>
+      <Link href="/resume">Resume</Link>
+      <Link href="/projects">Projects</Link>
+      <Link href="/contact">Contact</Link>
     </nav>
   )
 }


### PR DESCRIPTION
## Summary
- use `next/link` in the navigation bar
- update homepage call-to-action links to `next/link`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851204d24388329a1c48eff02c3bf64