### PR TITLE
Fix CSS comment syntax

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-// src/styles/globals.css
+/* src/styles/globals.css */
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- fix comment syntax at the top of `globals.css`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6851231f0c1483298339ac62ad18bb70