### PR TITLE
Fix CTA button contrast

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,7 @@ export default function HomePage() {
           <p className="text-xl mb-8 opacity-90">
             Discover tools, templates, and guides to enhance your DevOps journey
           </p>
-          <Link href="/resources" className="btn btn-secondary">
+          <Link href="/resources" className="btn btn-secondary cta-button">
             Browse Resources & Downloads
           </Link>
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -303,6 +303,17 @@ li {
   transform: translateY(-2px);
 }
 
+/* Button variant for gradient CTA sections */
+.cta-button {
+  color: var(--color-white);
+  border-color: var(--color-white);
+}
+
+.cta-button:hover {
+  background-color: var(--color-white);
+  color: var(--color-primary);
+}
+
 .btn-learn-more {
   align-self: flex-start;
   padding: 0.625rem 1.5rem;


### PR DESCRIPTION
## Summary
- adjust gradient CTA button to have white text and border
- add `.cta-button` class for clarity

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855257ba070832990c0fae507a3cab0