### PR TITLE
Make navbar logo link to homepage

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,7 +10,9 @@ export default function Navbar() {
   return (
     <nav className={`navbar${open ? ' open' : ''}`}> 
       <div className="container">
-        <div className="logo">Adesoji</div>
+        <Link href="/" className="logo">
+          Adesoji
+        </Link>
         <button
           className="nav-toggle"
           aria-label="Toggle navigation"

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -4,6 +4,7 @@ import Navbar from '../Navbar'
 describe('Navbar', () => {
   it('renders all navigation links', () => {
     render(<Navbar />)
+    expect(screen.getByRole('link', { name: /adesoji/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /about/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /resume/i })).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- make the logo in the navbar a link to `/`
- update navbar test to check for the logo link

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553c667db08329a075c9ca3e8d4880