### PR TITLE
Remove contact form from contact page

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import ContactForm from './ContactForm'
+// ContactForm removed
 import { Mail, MessageSquare, Clock } from 'lucide-react'
 
 // Note: Metadata exports don't work in Client Components
@@ -80,18 +80,6 @@ export default function ContactPage() {
               </div>
             </div>
 
-            {/* Contact Form */}
-            <div className="contact-form-wrapper" data-aos="fade-left">
-              <div className="contact-form-card">
-                <h3 className="text-center mb-6">Send a Message</h3>
-                <ContactForm />
-                <p className="form-footer">
-                  Prefer email? <a href="mailto:info@adesoji.dev" className="text-primary hover:underline">
-                    info@adesoji.dev
-                  </a>
-                </p>
-              </div>
-            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- update the contact page to omit the contact form

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685555da2e50832989cc7684e8752c5d