### PR TITLE
Fix unused import causing Next.js build error

### DIFF
--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import {
   Download,
-  FileText,
   Github,
   Calendar,
   CheckCircle,


### PR DESCRIPTION
## Summary
- remove unused `FileText` icon import from `resources` page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68559c6b28ac8329a8ae81948b905077